### PR TITLE
LightsOff: enable the end-of-puzzle dialog to pop up

### DIFF
--- a/src/GridView.cpp
+++ b/src/GridView.cpp
@@ -233,6 +233,7 @@ void GridView::MessageReceived(BMessage *msg)
 	}
 
 	if (index >= 0 && index <= 24) {
+		FlipButton(index);
 		fMoveCount++;
 		SetMovesLabel(fMoveCount);
 

--- a/src/TwoStateDrawButton.cpp
+++ b/src/TwoStateDrawButton.cpp
@@ -79,7 +79,6 @@ void TwoStateDrawButton::SetDisabled(BBitmap *disabledone, BBitmap *disabledtwo)
 void TwoStateDrawButton::MouseUp(BPoint pt)
 {
 	BButton::MouseUp(pt);
-	fButtonState = !fButtonState;
 	Invalidate();
 }
 


### PR DESCRIPTION
Fixes #16