### PR TITLE
Add key commands for stepping through the user's moves

### DIFF
--- a/src/Grid.cpp
+++ b/src/Grid.cpp
@@ -40,7 +40,7 @@ void Grid::Random(int8 minMoves)
 	// 3x3.png
 	if (fDimension == 3 && minMoves == 8) {
 		for (int8 index = 0; index < numButtons; index++)
-			fData[index] = fGrid[index] = 1;
+			fData[index] = 1;
 		fData[4] = 0;
 		return;
 	}
@@ -75,7 +75,8 @@ void Grid::Random(int8 minMoves)
 		int8 index;
 
 		// next random button not already marked
-		do index = random() % numButtons;
+		do
+			index = random() % numButtons;
 		while (fGrid[index]);
 
 		fGrid[index] = 1;	// mark the button to be pressed
@@ -101,7 +102,6 @@ void Grid::Random(int8 minMoves)
 		}
 }
 
-
 bool Grid::ValueAt(int8 x, int8 y)
 {
 	return fData[x + y * fDimension];
@@ -122,19 +122,19 @@ void Grid::SetValue(int8 offset, bool isOn)
 	fData[offset] = isOn;
 }
 
-void Grid::SetGridValues(uint32 value)
+void Grid::SetGridValues(uint64 value)
 {
 	for (int8 i = 0; i < fData.size(); i++)
-		fData[i] = (value & 1 << i) != 0;
+		fData[i] = (value & (uint64) 1 << i) != 0;
 }
 
-uint32 Grid::GetGridValues()
+uint64 Grid::GetGridValues()
 {
-	uint32 values = 0;
+	uint64 values = 0;
 
 	for (int8 i = 0; i < fData.size(); i++)
 		if(fData[i])
-			values |= 1 << i;
+			values |= (uint64) 1 << i;
 
 	return values;
 }

--- a/src/Grid.h
+++ b/src/Grid.h
@@ -5,7 +5,7 @@
 
 #include <SupportDefs.h>
 
-typedef std::vector<uint8> grid;
+typedef std::vector<int8> grid;
 
 // The Grid class performs data handling and translation for the lights
 // themselves and also makes it easy to write a level to disk. :)
@@ -22,8 +22,8 @@ public:
 	bool ValueAt(int8 offset);
 	void SetValue(int8 offset, bool isOn);
 	void SetValue(int8 x, int8 y, bool isOn);
-	void SetGridValues(uint32 value);
-	uint32 GetGridValues();
+	void SetGridValues(uint64 value);
+	uint64 GetGridValues();
 
 private:
 	int8 fDimension;

--- a/src/GridView.h
+++ b/src/GridView.h
@@ -1,6 +1,8 @@
 #ifndef GRID_VIEW_H
 #define GRID_VIEW_H
 
+#include <vector>
+
 #include <View.h>
 #include <Message.h>
 #include <Menu.h>
@@ -18,12 +20,14 @@ public:
 	GridView();
 	~GridView();
 	void MessageReceived(BMessage *msg);
+	void KeyDown(const char* bytes, int32 numBytes);
 	void AttachedToWindow();
 	void StartupPreferences();
 	void ShutdownPreferences();
 
 private:
 	void RandomMenu();
+	void PressButton(int8 index);
 	void FlipButton(int8 offset);
 	void UpdateButtons();
 	void UpdateGrid(BRect rect, int8 oldDimension);
@@ -33,6 +37,10 @@ private:
 	void SetPack(PuzzlePack *pack);
 	void SetMovesLabel(int8 count);
 	void HandleFinish();
+	void Restart();
+	void Undo();
+	void Redo();
+	void Restore();
 
 	TwoStateDrawButton **fButtons;
 	BMenu *fMenu, *fSoundMenu, *fRandomMenu, *fPackMenu, *fLevelMenu;
@@ -42,7 +50,9 @@ private:
 	PuzzlePack *fPuzzle;
 
 	bool fUseSound;
-	int8 fDimension, fLevel, fMoveCount;
+	int8 fDimension, fLevel, fMoveCount, fCurrentCount;
+	uint64 fPuzzleValues, fGridValues;
+	std::vector<int8> fMoves;
 
 	BFileGameSound *fClickSound, *fWinSound, *fNoWinSound;
 };


### PR DESCRIPTION
Use Home, End, and Left/Right Arrow keys to navigate through the moves:
* Home - restart the puzzle
* End - set the grid to user's last move
* Left/Right Arrow - step backward/forward

Fixes #44